### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,39 +8,39 @@
 
 [DATE]
 
-###Summary:
+### Summary:
 
 We will always do our best to fulfill your needs and meet your goals, but sometimes it is best to have a few simple things written down so that we both know what is what, who should do what and what happens if stuff goes wrong. In this contract you won't find complicated legal terms or large passages of unreadable text. We have no desire to trick you into signing something that you might later regret. We do want what's best for the safety of both parties, now and in the future.
 
-####In short:
+#### In short:
 
 You ([CLIENT COMPANY]) are hiring us ([MY COMPANY]) to [PROJECT NAME OR DESCRIPTION] at the hourly rate of [HOURLY RATE] per hour. Of course it's a little more complicated, but we'll get to that.
 
-###What do both parties agree to do?
+### What do both parties agree to do?
 
 As our customer, you have the power and ability to enter into this contract on behalf of your company or organization. You agree to provide us with everything that we need to complete the project including text, images and other information as and when we need it, and in the format that we ask for. You agree to review our work, provide feedback and sign-off approval in a timely manner. Deadlines work two ways and you will also be bound by any dates that we set together. You also agree to stick to the payment schedule set out at the end of this contract.
 
 We have the experience and ability to perform the services you need from us and we will carry them out in a professional and timely manner. Along the way we will endeavor to meet all the deadlines set but we can't be responsible for a missed launch date or a deadline if you have been late in supplying materials or have not approved or signed off our work on-time at any stage. On top of this we will also maintain the confidentiality of any information that you give us.
 
-###Getting down to the nitty gritty
+### Getting down to the nitty gritty
 
-####What we need from you
+#### What we need from you
 
 Below is a list of items we’ll need up front from you. Every project is slightly different, so there may be things we’ve missed from this list, but we will let you know as soon as we’re able if we’ve forgotten something we need.
 
 * [LIST OF NEEDS] *includes credentials, access to any necessary services or assets, etc*
 
-####Browser Compatibility
+#### Browser Compatibility
 We have agreed to test our code in IE7+ as well as the latest releases of Firefox, Safari, and Chrome. Additionally we test on mobile Safari and mobile Chrome (iOS devices, Android devices). If you need browsers other than those listed tested, please provide us with a list of the browsers and devices. Testing additional browsers requires more testing time as well as potentially needing to code for that specific browser.
 We code everything with progressive enhancement in mind. This means that modern browsers may show slight differences to older browsers (such as text and box shadows, rounded corners, etc) based on what a browser is able to render. Any changes will not affect the user experience.
 
-####Testing
+#### Testing
 We write tests before we write our code, which allows us to make sure that all required functionality is not only present, but works no matter how often we change things around. If your employees or other contractors will be working on the project along side us, we require that they also write tests for all code they produce to make sure we are all on the same page and not stepping on each others toes.
 
-####Version Control
+#### Version Control
 Git allows us to keep track of all changes that happen in your application. This way, if a bug is introduced we can quickly find where it was added and roll back to the previous bug-free state while we fix things up! We require code be under version control so we can work on your application with your employees or other contractors without worrying that we may be undoing or overwriting each others changes.
 
-####Timeline
+#### Timeline
 This project is scheduled to begin [START DATE] and will last a [PROJECT DURATION].
 Below is the milestone schedule:
 
@@ -48,19 +48,19 @@ Below is the milestone schedule:
 
 This contract will be declared complete when all work completed has been paid in full.
 
-####Additional development
+#### Additional development
 Any additional development needed above and beyond what we have agreed to here must be accompanied by an additional contract which we will be happy to provide upon request. We retain the right to refuse additional work that is not specifically outlined in this document.
 
-####Contact
+#### Contact
 All communications will be made during regular business hours (Monday-Friday, 9am-5pm CST, excluding holidays) and we will return any contact requests within one business day unless we notify you ahead of time that we will be out of the office. Of course we understand that emergencies do arise, so in the case of one know that our hours will be billed at time and a half. We appreciate communication in a text-based medium, but understand that not all discussions are easily done this way. We’re happy to speak to you on the phone, over Skype/Google Hangout, or in person if you are in the [MY CITY] area, keeping in mind that any decisions that are made will be written down and require your written approval.
 
 As we value your time as well as our own, we ask that all meetings be scheduled a minimum of two business days in advance and be accompanied by an agenda so that we can be fully prepared. If we are unable to attend a meeting at your suggested time, we will be happy to provide two times that will work for us. Meetings must start and end on or before the time allotted and will be charged for whether you attend or not.
 
-####Project Management
+#### Project Management
 If you do not have a preferred project management tool, we will provide you with a login for ours where you will be able to see the status of the project down to the specific task, so you will always be kept up to date. We’ll be relying on you to participate by answering our questions, stating your approval, requesting changes, and verifying completeness through the tool as well. We ask for a one business day turnaround time on responses so we can keep things moving along at a pace that will allow us to hit the milestones we decided on together. 
 To keep the project organized and the management of it easier, we prefer not to communicate any of the information stated above over ordinary email.
 
-###Legal stuff
+### Legal stuff
 
 Although we test extensively, we can't guarantee that the functions contained in any application will always be error-free and so we can't be liable to you or any third party for damages, including lost profits, lost savings or other incidental, consequential or special damages arising out of the operation of or inability to operate this application and any other web pages, even if you have advised us of the possibilities of such damages.
 
@@ -68,7 +68,7 @@ If any provision of this agreement shall be unlawful, void, or for any reason un
 
 Phew.
 
-####Copyrights
+#### Copyrights
 
 You guarantee to us that any elements of text, graphics, photos, designs, trademarks, or other artwork that you provide us for inclusion in the application are either owned by your good selves, or that you have permission to use them.
 
@@ -79,11 +79,11 @@ You own the graphics and other visual elements that we create for you for this p
 You also own text content, photographs and other data you provided, unless someone else owns them. We own the code we produced and we retain the rights to license it how we choose or to contribute it back to the open source project which it is based on.
 We love to show off our work and share what we have learned with other people, so we also reserve the right to display and link to your completed project as part of our portfolio and to write about the project on web sites, in magazine articles and in books as well as speak about them publicly at conferences. Of course we’re happy to keep this information to ourselves until your project goes live or 6 months from the handover date, whichever is sooner.
 
-###Payments
+### Payments
 
 We are sure you understand how important it is as a small business that you pay the invoices that we send you promptly.  As we're also sure you'll want to stay friends, you agree to stick tightly to the following payment schedule.
 
-####Payment Schedule
+#### Payment Schedule
 
 We bill every other week on Friday and all invoices are payable upon receipt.
 
@@ -93,13 +93,13 @@ Any payments not received within 7 days will halt work until the payment is rece
 
 If either party chooses to end the project, it must be done in writing. Please keep in mind that the deposit will be forfeited and any work that has been paid for up to that point will be turned over to you.
 
-###But where is all the horrible small print?
+### But where is all the horrible small print?
 
 Just like a parking ticket, you cannot transfer this contract to anyone else without our permission. This contract stays in place and need not be renewed. If for some reason one part of this contract becomes invalid or unenforceable, the remaining parts of it remain in place.
 
 Although the language is simple, the intentions are serious and this contract is a legal document under exclusive jurisdiction of [MY STATE] courts.
 
-###The dotted line
+### The dotted line
 
 
 __________________________________________________
@@ -110,4 +110,4 @@ __________________________________________________
 Signed by [DECISION MAKER] and on behalf of [CLIENT COMPANY]
 
 
-####Dated [DATE]
+#### Dated [DATE]


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
